### PR TITLE
#1 - add console log for missing namespace for 3rd parties domain

### DIFF
--- a/routes/_3rdparties.js
+++ b/routes/_3rdparties.js
@@ -1,0 +1,17 @@
+const c = require('ansi-colors');
+const nameSpace = require('./namespace');
+
+function thirdparty({url, headers}) {
+  const {tldomain} = global.mitm.fn;
+  const {origin, referer} = headers;
+  let domain = tldomain(url);
+
+  if (!nameSpace(domain)) {
+    if (origin && nameSpace(domain)) return;
+    if (referer && nameSpace(referer)) return;
+    console.log(c.redBright(`>> no-namespace (${domain})`));
+    return {namespace: domain};
+  }
+}
+
+module.exports = thirdparty;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,5 +1,6 @@
 const c = require('ansi-colors');
 const {extract, fetch} = require('./fetch');
+const _3rdparties    = require('./_3rdparties');
 const _jsResponse    = require('./_jsResponse');
 const _allResponse   = require('./_allResponse');
 const _chngRequest   = require('./_chngRequest');
@@ -29,6 +30,10 @@ module.exports =  ({route, browserName}) => {
     route.fulfill(_resp);
     return;
   }
+
+  if (_3rdparties(reqs)) {
+    return;
+  };
 
   let skip = _skipResponse(reqs);
   if (skip) {


### PR DESCRIPTION

Add console log info for 3rd parties domain who don't have namespace routes 

`>> no-namespace (h.online-metrix.net)`

![no-namespace](https://user-images.githubusercontent.com/11621/85598741-75fef880-b67e-11ea-866c-d5fb27f740c6.png)
